### PR TITLE
Enforce version bump.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ Metrics/BlockLength:
     - 'Rakefile'
     - '**/*.rake'
     - 'spec/**/*.rb'
+    - 'rubocop-vendor.gemspec'
 
 Metrics/LineLength:
   Max: 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## master (unreleased)
 
+## 0.2.1 - 2019-04-25
+
+### Added
+
+* Spec that checks version was bumped and changelog entry is present. ([@cabello][])
+
 ## 0.2.0 - 2019-04-23
 
 ### Added

--- a/lib/rubocop/vendor/version.rb
+++ b/lib/rubocop/vendor/version.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Vendor
     module Version
-      STRING = '0.2.0'
+      STRING = '0.2.1'
     end
   end
 end

--- a/rubocop-vendor.gemspec
+++ b/rubocop-vendor.gemspec
@@ -30,5 +30,7 @@ Gem::Specification.new do |s|
   }
 
   s.add_runtime_dependency('rubocop', '>= 0.53.0')
+  s.add_development_dependency('git')
+  s.add_development_dependency('keepachangelog')
   s.add_development_dependency('simplecov')
 end

--- a/spec/vendor/version_spec.rb
+++ b/spec/vendor/version_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'git'
+require 'keepachangelog'
+
+RSpec.describe 'a published gem' do # rubocop:disable RSpec/DescribeClass
+  def get_version(git, branch = 'HEAD')
+    git.grep('STRING = ', 'lib/**/version.rb', object: branch)
+       .map { |_sha, matches| matches.first[1] }
+       .map(&method(:parse_version))
+       .compact
+       .first
+  end
+
+  def parse_version(string)
+    string.match(/STRING = ['"](.*)['"]/)[1]
+  end
+
+  let(:git) { Git.open('.') }
+  let(:head_version) { get_version(git, 'HEAD') }
+  let(:master_version) { get_version(git, 'origin/master') }
+
+  it 'has a version number' do
+    expect(head_version).not_to be_nil
+  end
+
+  it 'has a bumped version committed' do
+    is_master_branch = git.current_branch == 'master' || master_version.nil?
+    skip('already on master branch, no need to compare versions') if is_master_branch
+
+    expect(Gem::Version.new(head_version)).to be > Gem::Version.new(master_version)
+  end
+
+  it 'has a CHANGELOG.md file' do
+    expect(File).to exist('CHANGELOG.md')
+  end
+
+  it 'has changelog entry for current version' do
+    parser = Keepachangelog::MarkdownParser.load('CHANGELOG.md')
+
+    expect(parser.parsed_content['versions'].keys).to include(start_with("#{head_version} - "))
+  end
+end


### PR DESCRIPTION
We want to guarantee version bumping when PRs are proposed otherwise the build fails.

Fixes #3 but not in the way it was described in the issue.