### PR TITLE
RollbarInsideRescue: accept ActiveSupport::Rescuable#rescue_from as rescue block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## master (unreleased)
 
+## 0.5.0 - 2019-05-13
+
+* `RollbarInsideRescue` accepts `ActiveSupport::Rescuable#rescue_from` as a valid rescue block. ([@marcotc][])
+
 ## 0.4.0 - 2019-05-13
 
 * Fix #6: Introduce `Vendor/RollbarInsideRescue`. ([@cabello][])
@@ -37,3 +41,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Introduce `Vendor/RollbarWithException` cop. ([@cabello][])
 
 [@cabello]: https://github.com/cabello
+[@marcotc]: https://github.com/marcotc

--- a/lib/rubocop/cop/vendor/rollbar_inside_rescue.rb
+++ b/lib/rubocop/cop/vendor/rollbar_inside_rescue.rb
@@ -22,6 +22,13 @@ module RuboCop
       #     Rollbar.error(exception, "Unable to sync account")
       #   end
       #
+      #   # good
+      #   class ApplicationController < ActionController::Base
+      #     rescue_from InvalidRecord do |e|
+      #       Rollbar.error(e)
+      #     end
+      #   end
+      #
       class RollbarInsideRescue < Cop
         MSG = 'Only call Rollbar when handling errors inside a `rescue` block.'
 
@@ -30,20 +37,28 @@ module RuboCop
             (const nil? :Rollbar) {:log :debug :info :warning :error :critical} ...)
         PATTERN
 
+        def_node_matcher :active_support_rescuable_block?, <<-PATTERN
+          (block
+            (send nil? :rescue_from ...) ...)
+        PATTERN
+
         def on_send(node)
           return unless rollbar?(node)
+          return if in_rescue_block?(node)
 
-          current_node = node.parent
-          until current_node.nil?
-            return if current_node.rescue_type?
+          add_offense(node, location: node.children[0].loc.expression)
+        end
+
+        def in_rescue_block?(node)
+          current_node = node
+
+          while (current_node = current_node.parent)
+            return true if current_node.rescue_type?
+            return true if active_support_rescuable_block?(current_node)
 
             break if current_node.def_type?
             break if current_node.class_type?
-
-            current_node = current_node.parent
           end
-
-          add_offense(node, location: node.children[0].loc.expression)
         end
       end
     end

--- a/lib/rubocop/vendor/version.rb
+++ b/lib/rubocop/vendor/version.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Vendor
     module Version
-      STRING = '0.4.0'
+      STRING = '0.5.0'
     end
   end
 end

--- a/manual/cops_vendor.md
+++ b/manual/cops_vendor.md
@@ -26,6 +26,13 @@ begin
 rescue StandardError => exception
   Rollbar.error(exception, "Unable to sync account")
 end
+
+# good
+class ApplicationController < ActionController::Base
+  rescue_from InvalidRecord do |e|
+    Rollbar.error(e)
+  end
+end
 ```
 
 ## Vendor/RollbarInterpolation

--- a/spec/rubocop/cop/vendor/rollbar_inside_rescue_spec.rb
+++ b/spec/rubocop/cop/vendor/rollbar_inside_rescue_spec.rb
@@ -45,9 +45,17 @@ RSpec.describe RuboCop::Cop::Vendor::RollbarInsideRescue do
     RUBY
   end
 
-  it 'does not register an offense when using `Rollbar.error with inline rescue' do
+  it 'does not register an offense when using `Rollbar.error` with inline rescue' do
     expect_no_offenses(<<-RUBY.strip_indent)
       1 / 0 rescue Rollbar.debug('Unable to perform division')
+    RUBY
+  end
+
+  it 'does not register offense when using `Rollbar.error` with ActiveSupport::Rescuable#rescue_from' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      rescue_from InvalidRecord do |e|
+        Rollbar.error(e)
+      end
     RUBY
   end
 end


### PR DESCRIPTION
`RollbarInsideRescue` cop currently considers a linting error to have a `Rollbar` call inside [`ActiveSupport::Rescuable#rescue_from`](https://api.rubyonrails.org/classes/ActiveSupport/Rescuable/ClassMethods.html#method-i-rescue_from), which is actually a valid replacement for a rescue block.

This PR makes `RollbarInsideRescue` cop `Rollbar` calls consider `ActiveSupport::Rescuable#rescue_from` a valid rescue block for wrapping a `Rollbar` call.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/wealthsimple/rubocop-vendor/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/wealthsimple/rubocop-vendor/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
