### PR TITLE
ci: add licenses workflow [skip ci]

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -1,0 +1,38 @@
+name: Save licenses report
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+jobs:
+  license_report:
+    name: Push license report to S3
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.ACTIONS_GITHUB_INTSVC_ROLE_TO_ASSUME }}
+          role-skip-session-tagging: true
+          role-duration-seconds: 900
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+        env:
+          BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
+          BUNDLE_NEXUS__IAD__W10EXTERNAL__COM: ${{ secrets.BUNDLE_NEXUS__IAD__W10EXTERNAL__COM }}
+
+      - name: Build and Push Report
+        uses: wealthsimple/toolbox-script@v1
+        with:
+          script: toolbox.licensed.run()
+


### PR DESCRIPTION
### NOTE: Please merge once this is approved.

#### Why
We need to make a report on all the licenses that are used in our repositories. This PR will create a Github Actions workflow that pushes a report on dependency licenses to Amazon S3.

#### What
- Added licenses.yml

#### Next steps
- Run this workflow for all repos (via api)

#### Questions / Concerns
If you have any questions you can post them in the #proj-github-actions Slack channel.
