### PR TITLE
Add cuncurrency to GitHub Actions workflow

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -7,6 +7,10 @@ on:
       - master
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   license_report:
     name: Push license report to S3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 ---
 name: Pipeline
 on: push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
#### Why

This adds a concurrency group to GitHub Actions workflows.

More info on what it is can be found [here](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency)
