### PR TITLE
Disallow Recursive Open Struct

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,3 +42,9 @@ Style/Documentation:
 Style/NumericPredicate:
   Exclude:
     - tasks/cops_documentation.rake
+
+Style/FormatStringToken:
+  # Because we parse a lot of source codes from strings. Percent arrays
+  # look like unannotated format string tokens to this cop.
+  Exclude:
+    - spec/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 - 2021-11-29
+### Changed
+- Disallow usage of the recursive-open-struct gem and its classes.
+
 ## 0.6.1 - 2021-04-16
 ### Changed
 - Updated dependencies

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,6 @@ gemspec
 gem 'byebug', platform: :mri
 gem 'rake'
 gem 'rspec'
-gem 'rubocop', github: 'rubocop-hq/rubocop'
+gem 'rubocop'
 gem 'rubocop-rspec', '~> 1.29.0'
 gem 'yard', '~> 0.9'

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,6 @@ gemspec
 gem 'byebug', platform: :mri
 gem 'rake'
 gem 'rspec'
-gem 'rubocop'
+gem 'rubocop', github: 'rubocop-hq/rubocop'
 gem 'rubocop-rspec', '~> 1.29.0'
 gem 'yard', '~> 0.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GIT
 PATH
   remote: .
   specs:
-    rubocop-vendor (0.6.1)
+    rubocop-vendor (0.7.0)
       rubocop (>= 0.53.0)
 
 GEM
@@ -83,4 +83,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.2.16
+   2.2.26

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,17 @@
+GIT
+  remote: https://github.com/rubocop-hq/rubocop.git
+  revision: 5ba77b920b545444bf777eae4152c3b229277989
+  specs:
+    rubocop (1.14.0)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.5.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+
 PATH
   remote: .
   specs:
@@ -17,13 +31,13 @@ GEM
     keepachangelog (0.6.1)
       json (~> 2.1)
       thor (~> 0.20)
-    parallel (1.21.0)
-    parser (3.0.3.1)
+    parallel (1.20.1)
+    parser (3.0.1.1)
       ast (~> 2.4.1)
     rainbow (3.0.0)
     rake (13.0.3)
     rchardet (1.8.0)
-    regexp_parser (2.2.0)
+    regexp_parser (2.1.1)
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -37,17 +51,8 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-support (3.10.3)
-    rubocop (1.23.0)
-      parallel (~> 1.10)
-      parser (>= 3.0.0.0)
-      rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.12.0, < 2.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.14.0)
+    rspec-support (3.10.2)
+    rubocop-ast (1.5.0)
       parser (>= 3.0.1.1)
     rubocop-rspec (1.29.1)
       rubocop (>= 0.58.0)
@@ -59,7 +64,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
     thor (0.20.3)
-    unicode-display_width (2.1.0)
+    unicode-display_width (2.0.0)
     yard (0.9.26)
 
 PLATFORMS
@@ -71,7 +76,7 @@ DEPENDENCIES
   keepachangelog
   rake
   rspec
-  rubocop
+  rubocop!
   rubocop-rspec (~> 1.29.0)
   rubocop-vendor!
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,3 @@
-GIT
-  remote: https://github.com/rubocop-hq/rubocop.git
-  revision: 5ba77b920b545444bf777eae4152c3b229277989
-  specs:
-    rubocop (1.14.0)
-      parallel (~> 1.10)
-      parser (>= 3.0.0.0)
-      rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.5.0, < 2.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-
 PATH
   remote: .
   specs:
@@ -31,13 +17,13 @@ GEM
     keepachangelog (0.6.1)
       json (~> 2.1)
       thor (~> 0.20)
-    parallel (1.20.1)
-    parser (3.0.1.1)
+    parallel (1.21.0)
+    parser (3.0.3.1)
       ast (~> 2.4.1)
     rainbow (3.0.0)
     rake (13.0.3)
     rchardet (1.8.0)
-    regexp_parser (2.1.1)
+    regexp_parser (2.2.0)
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -51,8 +37,17 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-support (3.10.2)
-    rubocop-ast (1.5.0)
+    rspec-support (3.10.3)
+    rubocop (1.23.0)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.12.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.14.0)
       parser (>= 3.0.1.1)
     rubocop-rspec (1.29.1)
       rubocop (>= 0.58.0)
@@ -64,7 +59,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
     thor (0.20.3)
-    unicode-display_width (2.0.0)
+    unicode-display_width (2.1.0)
     yard (0.9.26)
 
 PLATFORMS
@@ -76,7 +71,7 @@ DEPENDENCIES
   keepachangelog
   rake
   rspec
-  rubocop!
+  rubocop
   rubocop-rspec (~> 1.29.0)
   rubocop-vendor!
   simplecov

--- a/lib/rubocop/cop/vendor/recursive_open_struct_gem.rb
+++ b/lib/rubocop/cop/vendor/recursive_open_struct_gem.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Vendor
       # This cop flags uses of the recursive-open-struct gem.
       #
-      # RecrusiveOpenStruct inherits from OpenStruct, which is now officially discouraged to be used
+      # RecursiveOpenStruct inherits from OpenStruct, which is now officially discouraged to be used
       # for performance, version compatibility, and security issues.
       #
       # https://ruby-doc.org/stdlib-3.0.1/libdoc/ostruct/rdoc/OpenStruct.html#class-OpenStruct-label-Caveats

--- a/lib/rubocop/cop/vendor/recursive_open_struct_gem.rb
+++ b/lib/rubocop/cop/vendor/recursive_open_struct_gem.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Vendor
+      # This cop flags uses of the recursive-open-struct gem.
+      #
+      # RecrusiveOpenStruct inherits from OpenStruct, which is now officially discouraged to be used
+      # for performance, version compatibility, and security issues.
+      #
+      # https://ruby-doc.org/stdlib-3.0.1/libdoc/ostruct/rdoc/OpenStruct.html#class-OpenStruct-label-Caveats
+      class RecursiveOpenStructGem < Base
+        MSG = <<~MSG.strip
+          Do not use the recursive-open-struct gem. RecrusiveOpenStruct inherits from OpenStruct, which is now officially discouraged from usage due to performance, version compatibility, and security issues.
+        MSG
+
+        def on_new_investigation
+          return if processed_source.blank?
+
+          gem_declarations(processed_source.ast).each do |declaration|
+            next unless declaration.first_argument.str_content.match?('recursive-open-struct')
+
+            add_offense(declaration)
+          end
+        end
+
+        # @!method gem_declarations(node)
+        def_node_search :gem_declarations, <<~PATTERN
+          (:send nil? :gem str ...)
+        PATTERN
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/vendor/recursive_open_struct_gem.rb
+++ b/lib/rubocop/cop/vendor/recursive_open_struct_gem.rb
@@ -11,7 +11,7 @@ module RuboCop
       # https://ruby-doc.org/stdlib-3.0.1/libdoc/ostruct/rdoc/OpenStruct.html#class-OpenStruct-label-Caveats
       class RecursiveOpenStructGem < Base
         MSG = <<~MSG.strip
-          Do not use the recursive-open-struct gem. RecrusiveOpenStruct inherits from OpenStruct, which is now officially discouraged from usage due to performance, version compatibility, and security issues.
+          Do not use the recursive-open-struct gem. RecursiveOpenStruct inherits from OpenStruct, which is now officially discouraged from usage due to performance, version compatibility, and security issues.
         MSG
 
         def on_new_investigation

--- a/lib/rubocop/cop/vendor/recursive_open_struct_use.rb
+++ b/lib/rubocop/cop/vendor/recursive_open_struct_use.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop flags uses of RecursiveOpenStruct. RecursiveOpenStruct is a library used in the
       # Wealthsimple ecosystem that is being phased out due to security issues.
       #
-      # RecrusiveOpenStruct inherits from OpenStruct, which is now officially discouraged to be used
+      # RecursiveOpenStruct inherits from OpenStruct, which is now officially discouraged to be used
       # for performance, version compatibility, and security issues.
       #
       # @safety

--- a/lib/rubocop/cop/vendor/recursive_open_struct_use.rb
+++ b/lib/rubocop/cop/vendor/recursive_open_struct_use.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Vendor
+      # This cop flags uses of RecursiveOpenStruct. RecursiveOpenStruct is a library used in the
+      # Wealthsimple ecosystem that is being phased out due to security issues.
+      #
+      # RecrusiveOpenStruct inherits from OpenStruct, which is now officially discouraged to be used
+      # for performance, version compatibility, and security issues.
+      #
+      # @safety
+      #
+      #   Note that this cop may flag false positives; for instance, the following legal
+      #   use of a hand-rolled `RecursiveOpenStruct` type would be considered an offense:
+      #
+      #   ```
+      #   module MyNamespace
+      #     class RecursiveOpenStruct # not the RecursiveOpenStruct we're looking for
+      #     end
+      #
+      #     def new_struct
+      #       RecursiveOpenStruct.new # resolves to MyNamespace::RecursiveOpenStruct
+      #     end
+      #   end
+      #   ```
+      #
+      # @example
+      #
+      #   # bad
+      #   point = RecursiveOpenStruct.new(x: 0, y: 1)
+      #
+      #   # good
+      #   Point = Struct.new(:x, :y)
+      #   point = Point.new(0, 1)
+      #
+      #   # also good
+      #   point = { x: 0, y: 1 }
+      #
+      #   # bad
+      #   test_double = RecursiveOpenStruct.new(a: 'b')
+      #
+      #   # good (assumes test using rspec-mocks)
+      #   test_double = double
+      #   allow(test_double).to receive(:a).and_return('b')
+      #
+      class RecursiveOpenStructUse < Cop
+        MSG = <<~MSG.strip
+          Avoid using `RecursiveOpenStruct`; use `Struct`, `Hash`, a class or test doubles instead.
+        MSG
+
+        # @!method uses_recursive_open_struct?(node)
+        def_node_matcher :uses_recursive_open_struct?, <<-PATTERN
+          (const {nil? (cbase)} :RecursiveOpenStruct)
+        PATTERN
+
+        def on_const(node)
+          return unless uses_recursive_open_struct?(node)
+          return if custom_class_or_module_definition?(node)
+
+          add_offense(node)
+        end
+
+        private
+
+        def custom_class_or_module_definition?(node)
+          parent = node.parent
+
+          (parent.class_type? || parent.module_type?) && node.left_siblings.empty?
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/vendor_cops.rb
+++ b/lib/rubocop/cop/vendor_cops.rb
@@ -3,6 +3,7 @@
 module RuboCop
 end
 
+require_relative 'vendor/recursive_open_struct_gem'
 require_relative 'vendor/recursive_open_struct_use'
 require_relative 'vendor/rollbar_inside_rescue'
 require_relative 'vendor/rollbar_interpolation'

--- a/lib/rubocop/cop/vendor_cops.rb
+++ b/lib/rubocop/cop/vendor_cops.rb
@@ -3,6 +3,7 @@
 module RuboCop
 end
 
+require_relative 'vendor/recursive_open_struct_use'
 require_relative 'vendor/rollbar_inside_rescue'
 require_relative 'vendor/rollbar_interpolation'
 require_relative 'vendor/rollbar_log'

--- a/lib/rubocop/vendor/version.rb
+++ b/lib/rubocop/vendor/version.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Vendor
     module Version
-      STRING = '0.6.1'
+      STRING = '0.7.0'
     end
   end
 end

--- a/spec/rubocop/cop/vendor/recursive_open_struct_gem_spec.rb
+++ b/spec/rubocop/cop/vendor/recursive_open_struct_gem_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::Vendor::RecursiveOpenStructGem, :config do
     it 'registerers an offese' do
       expect_offense(<<~RUBY)
         gem 'recursive-open-struct'
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use the recursive-open-struct gem. RecrusiveOpenStruct inherits from OpenStruct, which is now officially discouraged from usage due to performance, version compatibility, and security issues.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use the recursive-open-struct gem. RecursiveOpenStruct inherits from OpenStruct, which is now officially discouraged from usage due to performance, version compatibility, and security issues.
       RUBY
     end
   end

--- a/spec/rubocop/cop/vendor/recursive_open_struct_gem_spec.rb
+++ b/spec/rubocop/cop/vendor/recursive_open_struct_gem_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Vendor::RecursiveOpenStructGem, :config do
+  let(:cop_config) { { 'TreatCommentsAsGroupSeparators' => treat_comments_as_group_separators } }
+  let(:treat_comments_as_group_separators) { false }
+
+  context 'When recursive-open-struct is not in the Gemfile' do
+    it 'does not register any offenses' do
+      expect_no_offenses(<<~RUBY)
+        gem 'rspec'
+        gem 'rubocop'
+      RUBY
+    end
+  end
+
+  context 'When recursive-open-struct is in the Gemfile' do
+    it 'registerers an offese' do
+      expect_offense(<<~RUBY)
+        gem 'recursive-open-struct'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use the recursive-open-struct gem. RecrusiveOpenStruct inherits from OpenStruct, which is now officially discouraged from usage due to performance, version compatibility, and security issues.
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/vendor/recursive_open_struct_use_spec.rb
+++ b/spec/rubocop/cop/vendor/recursive_open_struct_use_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Vendor::RecursiveOpenStructUse, :config do
+  context 'when using RecursiveOpenStruct' do
+    ['RecursiveOpenStruct', '::RecursiveOpenStruct'].each do |klass|
+      context "for #{klass}" do
+        context 'when used in assignments' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY, klass: klass)
+              a = %{klass}.new(a: 42)
+                  ^{klass} Avoid using `RecursiveOpenStruct`;[...]
+            RUBY
+          end
+        end
+
+        context 'when inheriting from it via <' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY, klass: klass)
+              class SubClass < %{klass}
+                               ^{klass} Avoid using `RecursiveOpenStruct`;[...]
+              end
+            RUBY
+          end
+        end
+
+        context 'when inheriting from it via Class.new' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY, klass: klass)
+              SubClass = Class.new(%{klass})
+                                   ^{klass} Avoid using `RecursiveOpenStruct`;[...]
+            RUBY
+          end
+        end
+      end
+    end
+  end
+
+  context 'when using custom namespaced RecursiveOpenStruct' do
+    context 'when inheriting from it' do
+      specify { expect_no_offenses('class A < SomeNamespace::RecursiveOpenStruct; end') }
+    end
+
+    context 'when defined in custom namespace' do
+      context 'when class' do
+        specify do
+          expect_no_offenses(<<~RUBY)
+            module SomeNamespace
+              class RecursiveOpenStruct
+              end
+            end
+          RUBY
+        end
+      end
+
+      context 'when module' do
+        specify do
+          expect_no_offenses(<<~RUBY)
+            module SomeNamespace
+              module RecursiveOpenStruct
+              end
+            end
+          RUBY
+        end
+      end
+    end
+
+    context 'when used in assignments' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          a = SomeNamespace::RecursiveOpenStruct.new
+        RUBY
+      end
+    end
+  end
+
+  context 'when not using RecursiveOpenStruct' do
+    it 'registers no offense', :aggregate_failures do
+      expect_no_offenses('class A < B; end')
+      expect_no_offenses('a = 42')
+    end
+  end
+end


### PR DESCRIPTION
Disallow the usage of `recursive-open-struct` and its classes.

## Why
RecursiveOpenStruct comes from a gem that we use in almost all of our Ruby apps. It inherits from OpenStruct.

The most recent version of Rubocop recommends against the use of OpenStruct. Ruby's own documentation gives a number of reasons not to use an OpenStruct, most notably the risk of a denial of service attack or the ability to overwrite methods: https://ruby-doc.org/stdlib-3.0.1/libdoc/ostruct/rdoc/OpenStruct.html#class-OpenStruct-label-Caveats

## What changed
Disallow the usage of RecursiveOpenStruct.

Most of this code is a copy of Rubocop's own rule for disallowing OpenStruct: https://github.com/rubocop/rubocop/pull/10217/files

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/wealthsimple/rubocop-vendor/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/wealthsimple/rubocop-vendor/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
