### PR TITLE
ci: update or add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/stale@v4
         with:
           days-before-stale: 30
-          days-before-close: 60
+          days-before-close: 30
           stale-pr-message: >
             This issue has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.7 - 2022-04-12
+### Changed
+- Close stale PRs in 60 days
+
 ## 0.8.6 - 2022-04-11
 ### Changed
 - Updated dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-vendor (0.8.6)
+    rubocop-vendor (0.8.7)
       rubocop (>= 0.53.0)
 
 GEM

--- a/lib/rubocop/vendor/version.rb
+++ b/lib/rubocop/vendor/version.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Vendor
     module Version
-      STRING = '0.8.6'
+      STRING = '0.8.7'
     end
   end
 end


### PR DESCRIPTION
### Why
We want to reduce the default amount of time it takes to close PRs that have been marked as `stale`, from 60 days to 30 days.

The stale workflow uses GitHub Actions to automatically mark PRs as stale and eventually close them if there is no detected activity. This workflow excludes any dependency or security PRs.

For more information about the stale GitHub Action see: https://github.com/actions/stale

### What changed
* Add `developer-tools` as a CODEOWNER for all GitHub Actions workflows (if applicable)
* If this repo has an existing `stale.yml` workflow, reduce the `days-before-close` from 60 to 30 (if applicable)
* If this repo _does not_ have a `stale.yml` workflow, add one!

:warning: **This PR was opened automatically!** :warning: Please reach out in #developer-tools on Slack if you have any questions!