### PR TITLE
ci: reduce frequency of stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: 'Close stale PRs'
 on:
   schedule:
-    - cron: '30 6 * * *' # 6:30 am UTC: 1:30 am EST
+    - cron: '30 6 1 * *' # 6:30 am UTC: 1:30 am EST on 1st day of the month
 
 jobs:
   stale:


### PR DESCRIPTION
### Why
We want to reduce the frequency of the `stale` workflow from daily to monthly.

The stale workflow uses GitHub Actions to automatically mark PRs as stale and eventually close them if there is no detected activity. This workflow excludes any dependency or security PRs.

For more information about the stale GitHub Action see: https://github.com/actions/stale

### What changed

* If this repo has an existing `stale.yml` workflow, change the cron to `'30 6 1 * *'`

:warning: **This PR was opened automatically!** :warning: Please reach out in #developer-tools on Slack if you have any questions!
