### PR TITLE
fix: bug in StrictDryStruct cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.9.1 - 2023-03-17
+### Changed
+- Fixed StrictDryStruct, it should only fail if declaring a Dry::Struct
+
 ## 0.9.0 - 2023-03-07
 ### Changed
 - Added cop to require strict schema on DryStruct

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-vendor (0.9.0)
+    rubocop-vendor (0.9.1)
       rubocop (>= 0.53.0)
 
 GEM

--- a/lib/rubocop/cop/vendor/strict_dry_struct.rb
+++ b/lib/rubocop/cop/vendor/strict_dry_struct.rb
@@ -22,6 +22,7 @@ module RuboCop
 
         def on_const(node)
           return unless uses_dry_struct?(node)
+          return unless node.parent.class_type?
           return if uses_strict_mode?(node.parent)
 
           add_offense(node)

--- a/lib/rubocop/vendor/version.rb
+++ b/lib/rubocop/vendor/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Vendor
-    VERSION = '0.9.0'
+    VERSION = '0.9.1'
   end
 end

--- a/spec/rubocop/cop/vendor/strict_dry_struct_spec.rb
+++ b/spec/rubocop/cop/vendor/strict_dry_struct_spec.rb
@@ -19,4 +19,10 @@ RSpec.describe RuboCop::Cop::Vendor::StrictDryStruct, :config, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense referring to Dry::Struct' do
+    expect_no_offenses(<<~RUBY)
+      expect { subject }.to raise_error Dry::Struct::Error
+    RUBY
+  end
 end


### PR DESCRIPTION
There was a bug in he StrictDryStruct cop. It was failing whenever Dry::Struct occurred in the code. It should only fail if we are declaring a subclass of Dry::Struct.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/wealthsimple/rubocop-vendor/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/wealthsimple/rubocop-vendor/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
