### PR TITLE
feat: add connection execute, manually memory leak cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.11.0 - 2023-05-26
+### Added
+- Add rule for `ActiveRecord::Connection#execute` since its manually memory managed (chance of memory leak)
+
 ## 0.10.0 - 2023-05-18
 ### Added
 - Add rule for sidekiq-throttled as it disables sidekiq-pro and sidekiq-enterprise functionality

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-vendor (0.10.0)
+    rubocop-vendor (0.11.0)
       rubocop (>= 0.53.0)
 
 GEM

--- a/lib/rubocop/cop/vendor/active_record_connection_execute.rb
+++ b/lib/rubocop/cop/vendor/active_record_connection_execute.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Vendor
+      # This cop checks for `ActiveRecord::Connection#execute` usage and suggests
+      # using non-manually memory managed objects instead.
+      #
+      # The main reason for this is this is a common way to leak memory in a Ruby on Rails application.
+      # see {
+      # https://github.com/rails/rails/blob/a19b13b61f7af612569943ec7d536185cbec875c/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L127
+      # ActiveRecord documentation
+      # }.
+      #
+      # @example
+      #   # bad
+      #   ActiveRecord::Base.connection.execute('SELECT * FROM users')
+      #   ApplicationRecord.connection.execute('SELECT * FROM users')
+      #   User.connection.execute('SELECT * FROM users')
+      #
+      #   # good
+      #   ActiveRecord::Base.connection.select_all('SELECT * FROM users')
+      #   ApplicationRecord.connection.select_all('SELECT * FROM users')
+      #   User.connection.select_all('SELECT * FROM users')
+      #
+      class ActiveRecordConnectionExecute < Base
+        MSG = <<-STR.strip
+          Use of `ActiveRecord::Connection#execute` returns manually memory managed object, consider using `select_one`, `select_all`, `insert`, `update`, `delete`. If necessary, you can also use `exec_query`, `exec_insert`, `exec_update`, `exec_delete`.
+        STR
+
+        # @!method connection_execute_method_call?(node)
+        def_node_matcher :connection_execute_method_call?, <<-PATTERN
+          (send (send _ :connection) :execute ...)
+        PATTERN
+
+        def on_send(node)
+          return unless connection_execute_method_call?(node)
+
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/vendor_cops.rb
+++ b/lib/rubocop/cop/vendor_cops.rb
@@ -3,6 +3,7 @@
 module RuboCop
 end
 
+require_relative 'vendor/active_record_connection_execute'
 require_relative 'vendor/recursive_open_struct_gem'
 require_relative 'vendor/sidekiq_throttled_gem'
 require_relative 'vendor/recursive_open_struct_use'

--- a/lib/rubocop/vendor/version.rb
+++ b/lib/rubocop/vendor/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Vendor
-    VERSION = '0.10.0'
+    VERSION = '0.11.0'
   end
 end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -1,6 +1,7 @@
 <!-- START_COP_LIST -->
 #### Department [Vendor](cops_vendor.md)
 
+* [Vendor/ActiveRecordConnectionExecute](cops_vendor.md#vendoractiverecordconnectionexecute)
 * [Vendor/RecursiveOpenStructGem](cops_vendor.md#vendorrecursiveopenstructgem)
 * [Vendor/RecursiveOpenStructUse](cops_vendor.md#vendorrecursiveopenstructuse)
 * [Vendor/RollbarInsideRescue](cops_vendor.md#vendorrollbarinsiderescue)

--- a/manual/cops_vendor.md
+++ b/manual/cops_vendor.md
@@ -1,5 +1,34 @@
 # Vendor
 
+## Vendor/ActiveRecordConnectionExecute
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | - | -
+
+This cop checks for `ActiveRecord::Connection#execute` usage and suggests
+using non-manually memory managed objects instead.
+
+The main reason for this is this is a common way to leak memory in a Ruby on Rails application.
+see {
+https://github.com/rails/rails/blob/a19b13b61f7af612569943ec7d536185cbec875c/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L127
+ActiveRecord documentation
+}.
+
+### Examples
+
+```ruby
+# bad
+ActiveRecord::Base.connection.execute('SELECT * FROM users')
+ApplicationRecord.connection.execute('SELECT * FROM users')
+User.connection.execute('SELECT * FROM users')
+
+# good
+ActiveRecord::Base.connection.select_all('SELECT * FROM users')
+ApplicationRecord.connection.select_all('SELECT * FROM users')
+User.connection.select_all('SELECT * FROM users')
+```
+
 ## Vendor/RecursiveOpenStructGem
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/spec/rubocop/cop/vendor/active_record_connection_execute_spec.rb
+++ b/spec/rubocop/cop/vendor/active_record_connection_execute_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Vendor::ActiveRecordConnectionExecute, :config do
+  it 'registers an offense when using `ActiveRecord::Base.connection.execute`' do
+    expect_offense(<<~RUBY)
+      ActiveRecord::Base.connection.execute('SELECT * FROM users')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use of `ActiveRecord::Connection#execute` returns manually memory managed object, consider using `select_one`, `select_all`, `insert`, `update`, `delete`. If necessary, you can also use `exec_query`, `exec_insert`, `exec_update`, `exec_delete`.
+    RUBY
+  end
+
+  it 'registers an offense when using `ApplicationRecord.connection.execute`' do
+    expect_offense(<<~RUBY)
+      ApplicationRecord.connection.execute('SELECT * FROM users')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use of `ActiveRecord::Connection#execute` returns manually memory managed object, consider using `select_one`, `select_all`, `insert`, `update`, `delete`. If necessary, you can also use `exec_query`, `exec_insert`, `exec_update`, `exec_delete`.
+    RUBY
+  end
+
+  it 'registers an offense when using `User.connection.execute`' do
+    expect_offense(<<~RUBY)
+      User.connection.execute('SELECT * FROM users')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use of `ActiveRecord::Connection#execute` returns manually memory managed object, consider using `select_one`, `select_all`, `insert`, `update`, `delete`. If necessary, you can also use `exec_query`, `exec_insert`, `exec_update`, `exec_delete`.
+    RUBY
+  end
+
+  it 'does not registers an offense when using `User.connection.select_all`' do
+    expect_no_offenses(<<~RUBY)
+      User.connection.select_all('SELECT * FROM users')
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/vendor/rollbar_log_spec.rb
+++ b/spec/rubocop/cop/vendor/rollbar_log_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Vendor::RollbarLog, :config, :config do
+RSpec.describe RuboCop::Cop::Vendor::RollbarLog, :config do
   it 'registers an offense when using `Rollbar.log` with string' do
     expect_offense(<<~RUBY)
       Rollbar.log('error', 'Unhandled exception')


### PR DESCRIPTION
Add rule for using `ActiveRecord::Connection#execute` since it is manually memory managed and can result in memory leaks.


NOTE: Ideally we could detect that its an `ActiveRecord::Connection` object, but that is hard to do statically in ruby.