### PR TITLE
feat: prefer after_create instead of after-commit due to transactional guarentees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.13.0 - 2023-11-27
 ### Added
-- Disallow `after_commit` as it has no transactional guarantee, switch to `before_commit`.
+- Disallow `after_commit` as it has no transactional guarantee, switch to `after_save`.
 
 ## 0.12.1 - 2023-08-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.13.0 - 2023-11-27
+### Added
+- Disallow `after_commit` as it has no transactional guarantee, switch to `before_commit`.
+
 ## 0.12.1 - 2023-08-01
 ### Fixed
 - Fixes for `ws-sdk` path injection rubocops

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-vendor (0.12.1)
+    rubocop-vendor (0.13.0)
       rubocop
 
 GEM

--- a/lib/rubocop/cop/vendor/disallow_after_commit.rb
+++ b/lib/rubocop/cop/vendor/disallow_after_commit.rb
@@ -8,7 +8,7 @@ module RuboCop
 
         NO_METH_MSG = "Do not not use `%<old>s` %<desc>s"
         NO_METHS = {
-          after_commit: "use `before_commit` because after_commit is non-transactional an may not run",
+          after_commit: "use `after_save` because `after_commit` is non-transactional an may not run",
         }.freeze
 
         def on_send(node)

--- a/lib/rubocop/cop/vendor/disallow_after_commit.rb
+++ b/lib/rubocop/cop/vendor/disallow_after_commit.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Vendor
+      class DisallowAfterCommit < Base
+        extend AutoCorrector
+
+        NO_METH_MSG = "You should not use `%<old>s` %<desc>s"
+        NO_METHS = {
+          after_commit: "generally you want `before_commit` as after_commit is non-transactional in guarentees of running",
+        }.freeze
+
+        def on_send(node)
+          name = node.method_name
+          if NO_METHS.key?(name)
+            add_offense(node, message: format(NO_METH_MSG, old: name, desc: NO_METHS[name]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/vendor/disallow_after_commit.rb
+++ b/lib/rubocop/cop/vendor/disallow_after_commit.rb
@@ -6,9 +6,9 @@ module RuboCop
       class DisallowAfterCommit < Base
         extend AutoCorrector
 
-        NO_METH_MSG = "You should not use `%<old>s` %<desc>s"
+        NO_METH_MSG = "Do not not use `%<old>s` %<desc>s"
         NO_METHS = {
-          after_commit: "generally you want `before_commit` as after_commit is non-transactional in guarentees of running",
+          after_commit: "use `before_commit` because after_commit is non-transactional an may not run",
         }.freeze
 
         def on_send(node)

--- a/lib/rubocop/cop/vendor_cops.rb
+++ b/lib/rubocop/cop/vendor_cops.rb
@@ -4,6 +4,7 @@ module RuboCop
 end
 
 require_relative 'vendor/active_record_connection_execute'
+require_relative 'vendor/disallow_after_commit'
 require_relative 'vendor/recursive_open_struct_gem'
 require_relative 'vendor/sidekiq_throttled_gem'
 require_relative 'vendor/recursive_open_struct_use'

--- a/lib/rubocop/vendor/version.rb
+++ b/lib/rubocop/vendor/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Vendor
-    VERSION = '0.12.1'
+    VERSION = '0.13.0'
   end
 end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -2,6 +2,7 @@
 #### Department [Vendor](cops_vendor.md)
 
 * [Vendor/ActiveRecordConnectionExecute](cops_vendor.md#vendoractiverecordconnectionexecute)
+* [Vendor/DisallowAfterCommit](cops_vendor.md#vendordisallowaftercommit)
 * [Vendor/RecursiveOpenStructGem](cops_vendor.md#vendorrecursiveopenstructgem)
 * [Vendor/RecursiveOpenStructUse](cops_vendor.md#vendorrecursiveopenstructuse)
 * [Vendor/RollbarInsideRescue](cops_vendor.md#vendorrollbarinsiderescue)

--- a/manual/cops_vendor.md
+++ b/manual/cops_vendor.md
@@ -29,11 +29,19 @@ ApplicationRecord.connection.select_all('SELECT * FROM users')
 User.connection.select_all('SELECT * FROM users')
 ```
 
-## Vendor/RecursiveOpenStructGem
+## Vendor/DisallowAfterCommit
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
 Enabled | Yes | No | - | -
+
+No documentation
+
+## Vendor/RecursiveOpenStructGem
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.1.0 | -
 
 This cop flags uses of the recursive-open-struct gem.
 
@@ -46,7 +54,7 @@ https://ruby-doc.org/stdlib-3.0.1/libdoc/ostruct/rdoc/OpenStruct.html#class-Open
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | - | -
+Enabled | Yes | No | 0.1.0 | -
 
 This cop flags uses of RecursiveOpenStruct. RecursiveOpenStruct is a library used in the
 Wealthsimple ecosystem that is being phased out due to security issues.
@@ -79,7 +87,7 @@ allow(test_double).to receive(:a).and_return('b')
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | - | -
+Enabled | Yes | No | 0.1.0 | -
 
 This cop checks for Rollbar calls outside `rescue` blocks.
 
@@ -205,7 +213,7 @@ Rollbar.error(exception, "Unable to sync account")
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | - | -
+Enabled | Yes | No | 0.1.0 | -
 
 This cop flags uses of the sidekiq-throttled gem.
 
@@ -220,7 +228,7 @@ https://wealthsimple.slack.com/archives/C19UB3HNZ/p1683721247371709 for more det
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | - | -
+Enabled | Yes | No | 0.1.0 | -
 
 This cop flags uses of DryStruct without strict mode
 
@@ -231,7 +239,7 @@ We want to enfore strict mode which will throw an error in that case.
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | - | -
+Enabled | Yes | No | 0.12.0 | -
 
 This cop checks for `Ws::Service#get,patch,post,put,delete,...` usage
 where the array format is used, but it contains (probably not) intended slashes.
@@ -251,7 +259,7 @@ Ws::AccountService.post(["test", "foo"])
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | - | -
+Enabled | Yes | No | 0.12.0 | -
 
 This cop checks for `Ws::Service#get,patch,post,put,delete,...` usage and suggests to use component based paths
 instead of using interpolated values that could be user input.

--- a/spec/rubocop/cop/vendor/disallow_after_commit_spec.rb
+++ b/spec/rubocop/cop/vendor/disallow_after_commit_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe RuboCop::Cop::Vendor::DisallowAfterCommit, :config do
   it 'registers an offense when using `after_commit` with no args' do
     expect_offense(<<~RUBY)
       after_commit
-      ^^^^^^^^^^^^ Do not not use `after_commit` use `before_commit` because after_commit is non-transactional an may not run
+      ^^^^^^^^^^^^ Do not not use `after_commit` use `after_save` because after_commit is non-transactional an may not run
     RUBY
   end
 
   it 'registers an offense when using `after_commit` with args' do
     expect_offense(<<~RUBY)
       after_commit :foo_bar
-      ^^^^^^^^^^^^^^^^^^^^^ Do not not use `after_commit` use `before_commit` because after_commit is non-transactional an may not run
+      ^^^^^^^^^^^^^^^^^^^^^ Do not not use `after_commit` use `after_save` because after_commit is non-transactional an may not run
     RUBY
   end
 end

--- a/spec/rubocop/cop/vendor/disallow_after_commit_spec.rb
+++ b/spec/rubocop/cop/vendor/disallow_after_commit_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe RuboCop::Cop::Vendor::DisallowAfterCommit, :config do
   it 'registers an offense when using `after_commit` with no args' do
     expect_offense(<<~RUBY)
       after_commit
-      ^^^^^^^^^^^^ You should not use `after_commit` generally you want `before_commit` as after_commit is non-transactional in guarentees of running
+      ^^^^^^^^^^^^ Do not not use `after_commit` use `before_commit` because after_commit is non-transactional an may not run
     RUBY
   end
 
   it 'registers an offense when using `after_commit` with args' do
     expect_offense(<<~RUBY)
       after_commit :foo_bar
-      ^^^^^^^^^^^^^^^^^^^^^ You should not use `after_commit` generally you want `before_commit` as after_commit is non-transactional in guarentees of running
+      ^^^^^^^^^^^^^^^^^^^^^ Do not not use `after_commit` use `before_commit` because after_commit is non-transactional an may not run
     RUBY
   end
 end

--- a/spec/rubocop/cop/vendor/disallow_after_commit_spec.rb
+++ b/spec/rubocop/cop/vendor/disallow_after_commit_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe RuboCop::Cop::Vendor::DisallowAfterCommit, :config do
   it 'registers an offense when using `after_commit` with no args' do
     expect_offense(<<~RUBY)
       after_commit
-      ^^^^^^^^^^^^ Do not not use `after_commit` use `after_save` because after_commit is non-transactional an may not run
+      ^^^^^^^^^^^^ Do not not use `after_commit` use `after_save` because `after_commit` is non-transactional an may not run
     RUBY
   end
 
   it 'registers an offense when using `after_commit` with args' do
     expect_offense(<<~RUBY)
       after_commit :foo_bar
-      ^^^^^^^^^^^^^^^^^^^^^ Do not not use `after_commit` use `after_save` because after_commit is non-transactional an may not run
+      ^^^^^^^^^^^^^^^^^^^^^ Do not not use `after_commit` use `after_save` because `after_commit` is non-transactional an may not run
     RUBY
   end
 end

--- a/spec/rubocop/cop/vendor/disallow_after_commit_spec.rb
+++ b/spec/rubocop/cop/vendor/disallow_after_commit_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Vendor::DisallowAfterCommit, :config do
+  it 'registers an offense when using `after_commit` with no args' do
+    expect_offense(<<~RUBY)
+      after_commit
+      ^^^^^^^^^^^^ You should not use `after_commit` generally you want `before_commit` as after_commit is non-transactional in guarentees of running
+    RUBY
+  end
+
+  it 'registers an offense when using `after_commit` with args' do
+    expect_offense(<<~RUBY)
+      after_commit :foo_bar
+      ^^^^^^^^^^^^^^^^^^^^^ You should not use `after_commit` generally you want `before_commit` as after_commit is non-transactional in guarentees of running
+    RUBY
+  end
+end


### PR DESCRIPTION
Generally `after_commit` can be dangerous as it means its completely non-transactional.

With the switch to using postgres backed job queue library (instead of redis); it now makes sense to queue the job within the commit in a `after_create`. Generally all `after_commit` has no guarantee of running and only things like logging really make sense in them (or anything that can be removed without consequence).

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/wealthsimple/rubocop-vendor/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/wealthsimple/rubocop-vendor/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
