### PR TITLE
fix: remove Rubocop rails config since this is not a Rails project

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
 inherit_gem:
   ws-style:
-    - default.yml
+    - core.yml
+    - rspec.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.12.2 - 2024-01-03
+### Changed
+- Removed Rubocop config for Rails
+
 ## 0.12.1 - 2023-08-01
 ### Fixed
 - Fixes for `ws-sdk` path injection rubocops

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-vendor (0.12.1)
+    rubocop-vendor (0.12.2)
       rubocop
 
 GEM

--- a/lib/rubocop/vendor/version.rb
+++ b/lib/rubocop/vendor/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Vendor
-    VERSION = '0.12.1'
+    VERSION = '0.12.2'
   end
 end


### PR DESCRIPTION
### Why
Noticed that there are some failures here: https://github.com/wealthsimple/rubocop-vendor/actions/runs/7388796069/job/20100323472?pr=101. Since this repository does not include Rails then we should not include the Rails cops. 

See README: https://github.com/wealthsimple/ws-style

### What
- Updated config to remove Rails Rubocop config