### PR TITLE
ci: use reusable workflow

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -1,0 +1,15 @@
+---
+name: Default
+
+on:
+  push:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_and_publish:
+    name: Build and Publish
+    uses: wealthsimple/public-github-workflows/.github/workflows/ruby-gem-build.yaml@main
+    secrets: inherit


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
Standardizing our ruby gem repository setup (CI and version spec)


#### What changed <!-- Summary of changes when modifying hundreds of lines -->
- Use reusable workflow
- Bring version spec up to date


<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
