### PR TITLE
chore: remove slack references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.13.1 - 2024-07-15
+### Changed
+- Removed Slack references
+
 ## 0.13.0 - 2024-01-11
 ### Changed
 - Added rule for `ActiveRecord::Base.transaction` use

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-vendor (0.13.0)
+    rubocop-vendor (0.13.1)
       rubocop
 
 GEM

--- a/lib/rubocop/cop/vendor/sidekiq_throttled_gem.rb
+++ b/lib/rubocop/cop/vendor/sidekiq_throttled_gem.rb
@@ -9,8 +9,6 @@ module RuboCop
       # resulting in at-most once delivery of sidekiq jobs, instead of at-least once delivery
       # of sidekiq jobs. This means there is a relatively good chance you will LOSE JOBS that were enqueued
       # if the sidekiq-process runs out of memory or does not shutdown gracefully.
-      #
-      # https://wealthsimple.slack.com/archives/C19UB3HNZ/p1683721247371709 for more details
       class SidekiqThrottledGem < Base
         MSG = <<~MSG.strip
           Do not use the sidekiq-throttled gem. sidekiq-throttled overrides the fetcher of sidekiq-pro and sidekiq-enterprise resulting in the ability to lose jobs (switch to at-most once processing).

--- a/lib/rubocop/vendor/version.rb
+++ b/lib/rubocop/vendor/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Vendor
-    VERSION = '0.13.0'
+    VERSION = '0.13.1'
   end
 end

--- a/manual/cops_vendor.md
+++ b/manual/cops_vendor.md
@@ -214,8 +214,6 @@ resulting in at-most once delivery of sidekiq jobs, instead of at-least once del
 of sidekiq jobs. This means there is a relatively good chance you will LOSE JOBS that were enqueued
 if the sidekiq-process runs out of memory or does not shutdown gracefully.
 
-https://wealthsimple.slack.com/archives/C19UB3HNZ/p1683721247371709 for more details
-
 ## Vendor/StrictDryStruct
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged


### PR DESCRIPTION
We are implementing a Slack retention policy, so these Slack messages are going to be removed. Removing references to Slack to prevent confusion in the future. I think that all the information needed is already contained in the comment, so we should be able to just remove the references.