### PR TITLE
fix typo in release task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.14.2 - 2024-03-13
+### Changed
+- Fix typo in release task
+
 ## 0.14.1 - 2024-03-13
 ### Changed
 - Fixed issue with deplicate metadata definitions.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-vendor (0.14.1)
+    rubocop-vendor (0.14.2)
       lint_roller
       rubocop
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ ways to do this:
 Put this into your `.rubocop.yml`.
 
 ```yaml
-require: rubocop-vendor
+plugins:
+ - rubocop-vendor
 ```
 
 Now you can run `rubocop` and it will automatically load the RuboCop Vendor

--- a/lib/rubocop/vendor/version.rb
+++ b/lib/rubocop/vendor/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Vendor
-    VERSION = '0.14.1'
+    VERSION = '0.14.2'
   end
 end

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -2,7 +2,7 @@
 
 require 'yard'
 require 'rubocop'
-require 'rubocop-vendor'
+require 'rubocop/vendor'
 
 YARD::Rake::YardocTask.new(:yard_for_generate_documentation) do |task|
   task.files = ['lib/rubocop/cop/**/*.rb']


### PR DESCRIPTION
The build in master is failing as `cops_documentation.rake` is still referencing the removed rubocop-vendor.rb file.
Fix the typo so the build can pass successfully.